### PR TITLE
fixed deleting all guild messages

### DIFF
--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -245,7 +245,7 @@
                     let resp;
                     try {
                         const s = Date.now();
-                        const API_DELETE_URL = `https://discordapp.com/api/v6/channels/${channelId}/messages/`;
+                        const API_DELETE_URL = `https://discordapp.com/api/v6/channels/${message.channel_id}/messages/`;
                         resp = await fetch(API_DELETE_URL + message.id, {
                             headers,
                             method: 'DELETE'


### PR DESCRIPTION
Heyo this is a "hacky" way I got it to delete all messages in a guild.
basically in the json response in each message there's the channel id that message comes from.