### PR TITLE
Fix #43, missing confirmation prompt after indexing or rate-limiting

### DIFF
--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -141,8 +141,6 @@
         };
 
         async function recurse() {
-            iterations++;
-
             let API_SEARCH_URL;
             if (guildId === '@me') {
                 API_SEARCH_URL = `https://discord.com/api/v6/channels/${channelId}/messages/`; // DMs
@@ -226,7 +224,7 @@
             
             if (myMessages.length > 0) {
 
-                if (iterations < 1) {
+                if (++iterations < 1) {
                     log.verb(`Waiting for your confirmation...`);
                     if (!await ask(`Do you want to delete ~${total} messages?\nEstimated time: ${etr}\n\n---- Preview ----\n` +
                         myMessages.map(m => `${m.author.username}#${m.author.discriminator}: ${m.attachments.length ? '[ATTACHMENTS]' : m.content}`).join('\n')))


### PR DESCRIPTION
Only increment `iterations` _just_ before we start deleting stuff. Otherwise we don't count it as an iteration because we had to index the channel or were rate-limited (or recieved some other error).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/victornpb/deletediscordmessages/74)
<!-- Reviewable:end -->
