### PR TITLE
Allow deletion of CHANNEL_PINNED_MESSAGE

### DIFF
--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -210,7 +210,7 @@
             if (!grandTotal) grandTotal = total;
             const myMessages = data.messages.map(convo => convo.find(message => message.hit===true));
             const systemMessages = myMessages.filter(msg => msg.type !== 0); // https://discord.com/developers/docs/resources/channel#message-object-message-types
-            const deletableMessages = myMessages.filter(msg => msg.type === 0);
+            const deletableMessages = myMessages.filter(msg => msg.type === 0 || msg.type === 6);
             const end = () => {
                 log.success(`Ended at ${new Date().toLocaleString()}! Total time: ${msToHMS(Date.now() - start.getTime())}`);
                 printDelayStats();


### PR DESCRIPTION
Announcement is created by system, but can be deleted by the person who pinned the message.

This helps towards #55, but it sounds like there are more messages being missed that this won't fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/victornpb/deletediscordmessages/75)
<!-- Reviewable:end -->
