### PR TITLE
[UI] Fix checkbox state

### DIFF
--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -45,7 +45,7 @@
         <button id="stop" style="background:#f04747;width:80px;" disabled>Stop</button>
         <button id="clear" style="width:80px;">Clear log</button>
         <label><input id="autoScroll" type="checkbox" checked>Auto scroll</label>
-        <label title="Hide sensitive information for taking screenshots"><input id="redact" type="checkbox" checked>Screenshot mode</label>
+        <label title="Hide sensitive information for taking screenshots"><input id="redact" type="checkbox">Screenshot mode</label>
         <progress id="progress" style="display:none;"></progress>
 
     </div>


### PR DESCRIPTION
In the legacy copy-paste version, the checkbox started out as checked instead of unchecked — this is in contrast to the actual "Screenshot mode" which starts out as disabled.

Signed-off-by: Atrate <Atrate@protonmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/victornpb/deletediscordmessages/121)
<!-- Reviewable:end -->
