### PR TITLE
Fixes API returned an empty page error

### DIFF
--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -335,7 +335,7 @@
 
                 return await recurse();
             } else {
-                if (data.total_results == 0) {
+                if (data.total_results === 0) {
                     log.warn('No deletable messages found.');
                     return end();
                 }

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -335,8 +335,15 @@
 
                 return await recurse();
             } else {
-                if (total - offset > 0) log.warn('Ended because API returned an empty page.');
-                return end();
+                if (data.total_results == 0) {
+                    log.warn('Ended because API returned an empty page.');
+                    return end();
+                }
+                
+                offset += skippedMessages.length;
+                await wait(1);
+                return await recurse();
+            }
             }
         }
 

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -336,7 +336,7 @@
                 return await recurse();
             } else {
                 if (data.total_results == 0) {
-                    log.warn('Ended because API returned an empty page.');
+                    log.warn('No deletable messages found.');
                     return end();
                 }
                 

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -335,8 +335,10 @@
 
                 return await recurse();
             } else {
-                if (data.total_results === 0) {
+                if (data.total_results != 0 && offset === data.total_results) {
                     log.warn('No deletable messages found.');
+                    return end();
+                } else if (data.total_results === 0) {
                     return end();
                 }
                 

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -341,9 +341,8 @@
                 }
                 
                 offset += skippedMessages.length;
-                await wait(1);
+                await wait(searchDelay);
                 return await recurse();
-            }
             }
         }
 

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -216,7 +216,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             return await recurse();
         } else {
                 if (data.total_results == 0) {
-                    llog.warn('No deletable messages found.');
+                    log.warn('No deletable messages found.');
                     return end();
                 }
                 

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -215,15 +215,14 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
 
             return await recurse();
         } else {
-                if (data.total_results == 0) {
-                    log.warn('No deletable messages found.');
-                    return end();
-                }
-                
-                offset += skippedMessages.length;
-                await wait(searchDelay);
-                return await recurse();
+            if (data.total_results === 0) {
+                log.warn('No deletable messages found.');
+                return end();
             }
+            
+            offset += skippedMessages.length;
+            await wait(searchDelay);
+            return await recurse();
         }
     }
 

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -216,7 +216,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             return await recurse();
         } else {
                 if (data.total_results == 0) {
-                    log.warn('Ended because API returned an empty page.');
+                    llog.warn('No deletable messages found.');
                     return end();
                 }
                 

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -215,8 +215,15 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
 
             return await recurse();
         } else {
-            if (total - offset > 0) log.warn('Ended because API returned an empty page.');
-            return end();
+                if (data.total_results == 0) {
+                    log.warn('Ended because API returned an empty page.');
+                    return end();
+                }
+                
+                offset += skippedMessages.length;
+                await wait(1);
+                return await recurse();
+            }
         }
     }
 

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -215,8 +215,10 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
 
             return await recurse();
         } else {
-            if (data.total_results === 0) {
+            if (data.total_results != 0 && offset === data.total_results) {
                 log.warn('No deletable messages found.');
+                return end();
+            } else if (data.total_results === 0) {
                 return end();
             }
             

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -221,7 +221,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 }
                 
                 offset += skippedMessages.length;
-                await wait(1);
+                await wait(searchDelay);
                 return await recurse();
             }
         }


### PR DESCRIPTION
Fixes issues like https://github.com/victornpb/deleteDiscordMessages/issues/153 where if there's "system messages" (basically messages that can't be deleted by the user) that are "owned" by the user the script terminates prematurely as it never bothers to look ahead. 

This has been tested in a few PMs of different sizes (<25, > 25 and over 10k) and appears to work without issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/victornpb/deletediscordmessages/157)
<!-- Reviewable:end -->
