### PR TITLE
Bump Discord API version to version 9 and add more message type to be deleted

### DIFF
--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -186,10 +186,10 @@
         async function recurse() {
             let API_SEARCH_URL;
             if (guildId === '@me') {
-                API_SEARCH_URL = `https://discord.com/api/v6/channels/${channelId}/messages/`; // DMs
+                API_SEARCH_URL = `https://discord.com/api/v9/channels/${channelId}/messages/`; // DMs
             }
             else {
-                API_SEARCH_URL = `https://discord.com/api/v6/guilds/${guildId}/messages/`; // Server
+                API_SEARCH_URL = `https://discord.com/api/v9/guilds/${guildId}/messages/`; // Server
             }
 
             const headers = {
@@ -296,7 +296,7 @@
                     let resp;
                     try {
                         const s = Date.now();
-                        const API_DELETE_URL = `https://discord.com/api/v6/channels/${message.channel_id}/messages/${message.id}`;
+                        const API_DELETE_URL = `https://discord.com/api/v9/channels/${message.channel_id}/messages/${message.id}`;
                         resp = await fetch(API_DELETE_URL, {
                             headers,
                             method: 'DELETE'

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -257,7 +257,7 @@
             if (!grandTotal) grandTotal = total;
             const discoveredMessages = data.messages.map(convo => convo.find(message => message.hit===true));
             const messagesToDelete = discoveredMessages.filter(msg => {
-                return msg.type === 0 || msg.type === 6 || (msg.pinned && includePinned);
+                return msg.type === 0 || (msg.type >= 6 && msg.type <= 21) || (msg.pinned && includePinned);
             });
             const skippedMessages = discoveredMessages.filter(msg=>!messagesToDelete.find(m=> m.id===msg.id));
 

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -62,10 +62,10 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
     async function recurse() {
         let API_SEARCH_URL;
         if (guildId === '@me') {
-            API_SEARCH_URL = `https://discord.com/api/v6/channels/${channelId}/messages/`; // DMs
+            API_SEARCH_URL = `https://discord.com/api/v9/channels/${channelId}/messages/`; // DMs
         }
         else {
-            API_SEARCH_URL = `https://discord.com/api/v6/guilds/${guildId}/messages/`; // Server
+            API_SEARCH_URL = `https://discord.com/api/v9/guilds/${guildId}/messages/`; // Server
         }
 
         const headers = {
@@ -166,7 +166,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 let resp;
                 try {
                     const s = Date.now();
-                    const API_DELETE_URL = `https://discord.com/api/v6/channels/${message.channel_id}/messages/${message.id}`;
+                    const API_DELETE_URL = `https://discord.com/api/v9/channels/${message.channel_id}/messages/${message.id}`;
                     resp = await fetch(API_DELETE_URL, {
                         headers,
                         method: 'DELETE'

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -127,7 +127,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
         if (!grandTotal) grandTotal = total;
         const discoveredMessages = data.messages.map(convo => convo.find(message => message.hit === true));
         const messagesToDelete = discoveredMessages.filter(msg => {
-            return msg.type === 0 || msg.type === 6 || (msg.pinned && includePinned);
+            return msg.type === 0 || (msg.type >= 6 && msg.type <= 21) || (msg.pinned && includePinned);
         });
         const skippedMessages = discoveredMessages.filter(msg => !messagesToDelete.find(m => m.id === msg.id));
 

--- a/help/authToken.md
+++ b/help/authToken.md
@@ -4,7 +4,7 @@
 
 1. On the DevTools, Open the "Network" tab
 3. Click on "XHR"
-4. Type `api/v6` on the filter box.
+4. Type `api/v9` on the filter box.
 5. Click on any request in the list, and then click on "Headers" tab in the side panel.
   You're looking for something like this **authorization:** `MTX5MzQ1MjAyMjU0NjA2MzM2.ROFLMAO.UvqZqBMXLpDuOY3Z456J3JRIfbk`.
 


### PR DESCRIPTION
Discord clients are now using the [version 9](https://discord.com/developers/docs/reference#api-versioning) of the Discord API.

Version 9 is required in order to be able to use [Threads](https://discord.com/developers/docs/topics/threads).

This pull request also adds more [message types](https://discord.com/developers/docs/resources/channel#message-object-message-types) to be deleted (≥6 & ≤21).
![image](https://user-images.githubusercontent.com/1633366/124478925-fbdf7480-dda5-11eb-90d2-20fbe81ff5a4.png)
As far as I know they are all messages types that can be deleted without any issue.

---

Please note that the script currently does not work on Threads as they don't seem to be indexed.

```json
{"message": "Missing Access", "code": 50001}
```

I'm not sure if it's a bug or a limitation of the early access.
Anyway this is something to look for as Threads aren't a released feature yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/victornpb/deletediscordmessages/223)
<!-- Reviewable:end -->
