### PR TITLE
Retry deletion of message if deletion fails

### DIFF
--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -308,6 +308,7 @@
                             avgPing = (avgPing*0.9) + (lastPing*0.1);
                             delCount++;
                         } catch (err) {
+                            await wait(deleteDelay);
                             log.error('Delete request throwed an error:', err);
                             log.verb('Related object:', redact(JSON.stringify(message)));
                             failCount++;

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -316,7 +316,7 @@
                             failCount++;
                             delErr = true;
                         }
-                    }while(deleteError);
+                    }while(deleteError && delErrCount < 5); // retry deleting a message up to five times if there's an error
 
                     if (!resp.ok) {
                         // deleting messages too fast

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -294,6 +294,8 @@
                     if (onProgress) onProgress(delCount + 1, grandTotal);
                     
                     let resp;
+                    let deleteErrorCount = 0;
+                    let deleteError = false;
                     try {
                         const s = Date.now();
                         const API_DELETE_URL = `https://discord.com/api/v6/channels/${message.channel_id}/messages/${message.id}`;

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -309,12 +309,12 @@
                             avgPing = (avgPing*0.9) + (lastPing*0.1);
                             delCount++;
                         } catch (err) {
-                            await wait(deleteDelay);
                             log.error('Delete request throwed an error:', err);
                             log.verb('Related object:', redact(JSON.stringify(message)));
                             delErrCount++;
                             failCount++;
                             delErr = true;
+                            await wait(10000);
                         }
                     }while(delErr && delErrCount < 5); // retry deleting a message up to five times if there's an error
 

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -316,7 +316,7 @@
                             failCount++;
                             delErr = true;
                         }
-                    }while(deleteError && delErrCount < 5); // retry deleting a message up to five times if there's an error
+                    }while(delErr && delErrCount < 5); // retry deleting a message up to five times if there's an error
 
                     if (!resp.ok) {
                         // deleting messages too fast

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -296,21 +296,23 @@
                     let resp;
                     let deleteErrorCount = 0;
                     let deleteError = false;
-                    try {
-                        const s = Date.now();
-                        const API_DELETE_URL = `https://discord.com/api/v6/channels/${message.channel_id}/messages/${message.id}`;
-                        resp = await fetch(API_DELETE_URL, {
-                            headers,
-                            method: 'DELETE'
-                        });
-                        lastPing = (Date.now() - s);
-                        avgPing = (avgPing*0.9) + (lastPing*0.1);
-                        delCount++;
-                    } catch (err) {
-                        log.error('Delete request throwed an error:', err);
-                        log.verb('Related object:', redact(JSON.stringify(message)));
-                        failCount++;
-                    }
+                    do{
+                        try {
+                            const s = Date.now();
+                            const API_DELETE_URL = `https://discord.com/api/v6/channels/${message.channel_id}/messages/${message.id}`;
+                            resp = await fetch(API_DELETE_URL, {
+                                headers,
+                                method: 'DELETE'
+                            });
+                            lastPing = (Date.now() - s);
+                            avgPing = (avgPing*0.9) + (lastPing*0.1);
+                            delCount++;
+                        } catch (err) {
+                            log.error('Delete request throwed an error:', err);
+                            log.verb('Related object:', redact(JSON.stringify(message)));
+                            failCount++;
+                        }
+                    }while(deleteError);
 
                     if (!resp.ok) {
                         // deleting messages too fast

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -311,6 +311,7 @@
                             await wait(deleteDelay);
                             log.error('Delete request throwed an error:', err);
                             log.verb('Related object:', redact(JSON.stringify(message)));
+                            deleteErrorCount++;
                             failCount++;
                         }
                     }while(deleteError);

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -153,6 +153,8 @@
         const delayAdjustmentThreshold = 5; // ms
         let baseDeleteDelay = 100;
         let deleteDelay = baseDeleteDelay;
+        let baseRetryDelay = 5000;
+        let retryDelay = 5000;
         let baseSearchDelay = 100;
         let searchDelay = baseSearchDelay;
         let delCount = 0;
@@ -171,7 +173,7 @@
         const redact = str => `<span class="priv">${escapeHTML(str)}</span><span class="mask">REDACTED</span>`;
         const queryString = params => params.filter(p => p[1] !== undefined).map(p => p[0] + '=' + encodeURIComponent(p[1])).join('&');
         const ask = async msg => new Promise(resolve => setTimeout(() => resolve(popup.confirm(msg)), 10));
-        const printDelayStats = () => log.verb(`Delete delay: ${deleteDelay}ms, Search delay: ${searchDelay}ms`, `Last Ping: ${lastPing}ms, Average Ping: ${avgPing|0}ms`);
+        const printDelayStats = () => log.verb(`Delete delay: ${deleteDelay}ms, Search delay: ${searchDelay}ms`, `Retry delay: ${retryDelay}ms,` `Last Ping: ${lastPing}ms, Average Ping: ${avgPing|0}ms`);
         const toSnowflake = (date) => /:/.test(date) ? ((new Date(date).getTime() - 1420070400000) * Math.pow(2, 22)) : date;
             
         const log = {
@@ -314,7 +316,7 @@
                             delErrCount++;
                             failCount++;
                             delErr = true;
-                            await wait(10000);
+                            await wait(retryDelay);
                         }
                     }while(delErr && delErrCount < 5); // retry deleting a message up to five times if there's an error
 

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -312,7 +312,7 @@
                             await wait(deleteDelay);
                             log.error('Delete request throwed an error:', err);
                             log.verb('Related object:', redact(JSON.stringify(message)));
-                            deleteErrorCount++;
+                            delErrCount++;
                             failCount++;
                         }
                     }while(deleteError);

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -318,23 +318,25 @@
                         }
                     }while(delErr && delErrCount < 5); // retry deleting a message up to five times if there's an error
 
-                    if (!resp.ok) {
-                        // deleting messages too fast
-                        if (resp.status === 429) {
-                            const w = (await resp.json()).retry_after;
-                            throttledCount++;
-                            throttledTotalTime += w;
-                            baseDeleteDelay = deleteDelay;
-                            deleteDelay = w > baseDeleteDelay ? w : baseDeleteDelay;
-                            log.warn(`Being rate limited by the API for ${w}ms! Increasing delete delay to ${deleteDelay}ms, adjusting base delete delay to ${baseDeleteDelay}ms`);
-                            printDelayStats();
-                            log.verb(`Cooling down for ${w*2}ms before retrying...`);
-                            await wait(w*2);
-                            i--; // retry
-                        } else {
-                            log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
-                            log.verb('Related object:', redact(JSON.stringify(message)));
-                            failCount++;
+                    if (typeof resp != "undefined"){
+                        if (!resp.ok) {
+                            // deleting messages too fast
+                            if (resp.status === 429) {
+                                const w = (await resp.json()).retry_after;
+                                throttledCount++;
+                                throttledTotalTime += w;
+                                baseDeleteDelay = deleteDelay;
+                                deleteDelay = w > baseDeleteDelay ? w : baseDeleteDelay;
+                                log.warn(`Being rate limited by the API for ${w}ms! Increasing delete delay to ${deleteDelay}ms, adjusting base delete delay to ${baseDeleteDelay}ms`);
+                                printDelayStats();
+                                log.verb(`Cooling down for ${w*2}ms before retrying...`);
+                                await wait(w*2);
+                                i--; // retry
+                            } else {
+                                log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
+                                log.verb('Related object:', redact(JSON.stringify(message)));
+                                failCount++;
+                            }
                         }
                     }
                     else if (deleteDelay - baseDeleteDelay > delayAdjustmentThreshold)

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -298,6 +298,7 @@
                     let delErr = false;
                     do{
                         try {
+                            delErr = false;
                             const s = Date.now();
                             const API_DELETE_URL = `https://discord.com/api/v6/channels/${message.channel_id}/messages/${message.id}`;
                             resp = await fetch(API_DELETE_URL, {

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -294,8 +294,8 @@
                     if (onProgress) onProgress(delCount + 1, grandTotal);
                     
                     let resp;
-                    let deleteErrorCount = 0;
-                    let deleteError = false;
+                    let delErrCount = 0;
+                    let delErr = false;
                     do{
                         try {
                             const s = Date.now();

--- a/deleteDiscordMessages.js
+++ b/deleteDiscordMessages.js
@@ -314,6 +314,7 @@
                             log.verb('Related object:', redact(JSON.stringify(message)));
                             delErrCount++;
                             failCount++;
+                            delErr = true;
                         }
                     }while(deleteError);
 

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -181,6 +181,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                         await wait(deleteDelay);
                         log.error('Delete request throwed an error:', err);
                         log.verb('Related object:', redact(JSON.stringify(message)));
+                        deleteErrorCount++;
                         failCount++;
                     }
                 }while(deleteError);

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -186,7 +186,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                         failCount++;
                         delErr = true;
                     }
-                }while(deleteError);
+                }while(deleteError && delErrCount < 5); // retry deleting a message up to five times if there's an error
 
                 if (!resp.ok) {
                     // deleting messages too fast

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -164,8 +164,8 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 if (onProgress) onProgress(delCount + 1, grandTotal);
 
                 let resp;
-                let deleteErrorCount = 0;
-                let deleteError = false;
+                let delErrCount = 0;
+                let delErr = false;
                 do{
                     try {
                         const s = Date.now();

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -184,6 +184,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                         log.verb('Related object:', redact(JSON.stringify(message)));
                         delErrCount++;
                         failCount++;
+                        delErr = true;
                     }
                 }while(deleteError);
 

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -182,7 +182,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                         await wait(deleteDelay);
                         log.error('Delete request throwed an error:', err);
                         log.verb('Related object:', redact(JSON.stringify(message)));
-                        deleteErrorCount++;
+                        delErrCount++;
                         failCount++;
                     }
                 }while(deleteError);

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -179,12 +179,12 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                         avgPing = (avgPing*0.9) + (lastPing*0.1);
                         delCount++;
                     } catch (err) {
-                        await wait(deleteDelay);
                         log.error('Delete request throwed an error:', err);
                         log.verb('Related object:', redact(JSON.stringify(message)));
                         delErrCount++;
                         failCount++;
                         delErr = true;
+                        await wait(10000);
                     }
                 }while(delErr && delErrCount < 5); // retry deleting a message up to five times if there's an error
 

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -166,21 +166,23 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 let resp;
                 let deleteErrorCount = 0;
                 let deleteError = false;
-                try {
-                    const s = Date.now();
-                    const API_DELETE_URL = `https://discord.com/api/v6/channels/${message.channel_id}/messages/${message.id}`;
-                    resp = await fetch(API_DELETE_URL, {
-                        headers,
-                        method: 'DELETE'
-                    });
-                    lastPing = (Date.now() - s);
-                    avgPing = (avgPing * 0.9) + (lastPing * 0.1);
-                    delCount++;
-                } catch (err) {
-                    log.error('Delete request throwed an error:', err);
-                    log.verb('Related object:', redact(JSON.stringify(message)));
-                    failCount++;
-                }
+                do{
+                    try {
+                        const s = Date.now();
+                        const API_DELETE_URL = `https://discord.com/api/v6/channels/${message.channel_id}/messages/${message.id}`;
+                        resp = await fetch(API_DELETE_URL, {
+                            headers,
+                            method: 'DELETE'
+                        });
+                        lastPing = (Date.now() - s);
+                        avgPing = (avgPing*0.9) + (lastPing*0.1);
+                        delCount++;
+                    } catch (err) {
+                        log.error('Delete request throwed an error:', err);
+                        log.verb('Related object:', redact(JSON.stringify(message)));
+                        failCount++;
+                    }
+                }while(deleteError);
 
                 if (!resp.ok) {
                     // deleting messages too fast

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -164,6 +164,8 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 if (onProgress) onProgress(delCount + 1, grandTotal);
 
                 let resp;
+                let deleteErrorCount = 0;
+                let deleteError = false;
                 try {
                     const s = Date.now();
                     const API_DELETE_URL = `https://discord.com/api/v6/channels/${message.channel_id}/messages/${message.id}`;

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -188,22 +188,24 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                     }
                 }while(delErr && delErrCount < 5); // retry deleting a message up to five times if there's an error
 
-                if (!resp.ok) {
-                    // deleting messages too fast
-                    if (resp.status === 429) {
-                        const w = (await resp.json()).retry_after;
-                        throttledCount++;
-                        throttledTotalTime += w;
-                        deleteDelay = w; // increase delay
-                        log.warn(`Being rate limited by the API for ${w}ms! Adjusted delete delay to ${deleteDelay}ms.`);
-                        printDelayStats();
-                        log.verb(`Cooling down for ${w * 2}ms before retrying...`);
-                        await wait(w * 2);
-                        i--; // retry
-                    } else {
-                        log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
-                        log.verb('Related object:', redact(JSON.stringify(message)));
-                        failCount++;
+                if (typeof resp != "undefined"){
+                    if (!resp.ok) {
+                        // deleting messages too fast
+                        if (resp.status === 429) {
+                            const w = (await resp.json()).retry_after;
+                            throttledCount++;
+                            throttledTotalTime += w;
+                            deleteDelay = w; // increase delay
+                            log.warn(`Being rate limited by the API for ${w}ms! Adjusted delete delay to ${deleteDelay}ms.`);
+                            printDelayStats();
+                            log.verb(`Cooling down for ${w * 2}ms before retrying...`);
+                            await wait(w * 2);
+                            i--; // retry
+                        } else {
+                            log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
+                            log.verb('Related object:', redact(JSON.stringify(message)));
+                            failCount++;
+                        }
                     }
                 }
 

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -186,7 +186,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                         failCount++;
                         delErr = true;
                     }
-                }while(deleteError && delErrCount < 5); // retry deleting a message up to five times if there's an error
+                }while(delErr && delErrCount < 5); // retry deleting a message up to five times if there's an error
 
                 if (!resp.ok) {
                     // deleting messages too fast

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -168,6 +168,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 let delErr = false;
                 do{
                     try {
+                        delErr = false;
                         const s = Date.now();
                         const API_DELETE_URL = `https://discord.com/api/v6/channels/${message.channel_id}/messages/${message.id}`;
                         resp = await fetch(API_DELETE_URL, {

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -29,7 +29,7 @@
  * @author Victornpb <https://www.github.com/victornpb>
  * @see https://github.com/victornpb/deleteDiscordMessages
  */
-async function deleteMessages(authToken, authorId, guildId, channelId, minId, maxId, content, hasLink, hasFile, includeNsfw, includePinned, searchDelay, deleteDelay, extLogger, stopHndl, onProgress) {
+async function deleteMessages(authToken, authorId, guildId, channelId, minId, maxId, content, hasLink, hasFile, includeNsfw, includePinned, searchDelay, deleteDelay, retryDelay, extLogger, stopHndl, onProgress) {
     const start = new Date();
     let delCount = 0;
     let failCount = 0;
@@ -184,7 +184,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                         delErrCount++;
                         failCount++;
                         delErr = true;
-                        await wait(10000);
+                        await wait(retryDelay);
                     }
                 }while(delErr && delErrCount < 5); // retry deleting a message up to five times if there's an error
 
@@ -324,6 +324,12 @@ function initUI() {
                 target="_blank">?</a><br>
                     <input id="deleteDelay" type="number" value="1000" step="100">
                 </span>
+                </span>
+                <span>Retry Delay <a
+                href="https://github.com/victornpb/deleteDiscordMessages/blob/master/help/delay.md" title="Help"
+                target="_blank">?</a><br>
+                    <input id="retryDelay" type="number" value="5000" step="1000">
+                </span>
             </div>
             <hr>
             <button id="start" style="background:#43b581;width:80px;">Start</button>
@@ -397,6 +403,7 @@ function initUI() {
         const includePinned = $('input#includePinned').checked;
         const searchDelay = parseInt($('input#searchDelay').value.trim());
         const deleteDelay = parseInt($('input#deleteDelay').value.trim());
+        const retryDelay = parseInt($('input#retryDelay').value.trim());
         const progress = $('#progress');
         const progress2 = btn.querySelector('progress');
         const percent = $('.percent');
@@ -431,7 +438,7 @@ function initUI() {
 
         stop = stopBtn.disabled = !(startBtn.disabled = true);
         for (let i = 0; i < channelIds.length; i++) {
-            await deleteMessages(authToken, authorId, guildId, channelIds[i], minId || minDate, maxId || maxDate, content, hasLink, hasFile, includeNsfw, includePinned, searchDelay, deleteDelay, logger, stopHndl, onProg);
+            await deleteMessages(authToken, authorId, guildId, channelIds[i], minId || minDate, maxId || maxDate, content, hasLink, hasFile, includeNsfw, includePinned, searchDelay, deleteDelay, retryDelay, logger, stopHndl, onProg);
             stop = stopBtn.disabled = !(startBtn.disabled = false);
         }
     };

--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -178,6 +178,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                         avgPing = (avgPing*0.9) + (lastPing*0.1);
                         delCount++;
                     } catch (err) {
+                        await wait(deleteDelay);
                         log.error('Delete request throwed an error:', err);
                         log.verb('Related object:', redact(JSON.stringify(message)));
                         failCount++;

--- a/help/delay.md
+++ b/help/delay.md
@@ -1,3 +1,6 @@
-# Search and Delete Delay
+# Search, Delete and Retry Delay
 
 This setting controls the initial delay for for searching messages. Sometimes the Discord API will quickly rate limit you, in this case setting the delays to something higher might help. This is especially true for the **Delete Delay**.
+
+
+The retry delay is a value that delays how long the script should wait before trying to delete the same message again if there was an error trying to delete it.


### PR DESCRIPTION
**Bug being solved:**
Prior to these changes, if deleting a message threw an error, the script would stop deleting any more messages. This was inconvenient because on slower connections a deletion may time out from time to time and throw an error, which would cause the script to stop. 


**Changes:**
- Now the script tries to delete the message 5 times with an adjustable delay in-between attempts. If after 5 attempts the deletion fails, the script moves onto the next message.
- An option was added to the UI to adjust the retry delay. Meaning that if deleting a message throws an error, you can chose how long the program will wait before attempting to delete it again.

**Implementation:**

I wrapped the code to delete a message in a do while block and used two variables to ensure the block would get run again if there was an error after trying to delete the message (for a maximum of 5 reattempts). If there was no error, the script would move on to the next message.

To ensure the script would continue working if there was an error when deleting the message, I nested the "if (!resp.ok)" statement within an if statement that wouldn't evaluate to true if resp was undefined (this fixed the script stopping if deleting the message threw an error).