### PR TITLE
Update API to v9 (tested)

### DIFF
--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -62,10 +62,10 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
     async function recurse() {
         let API_SEARCH_URL;
         if (guildId === '@me') {
-            API_SEARCH_URL = `https://discord.com/api/v6/channels/${channelId}/messages/`; // DMs
+            API_SEARCH_URL = `https://discord.com/api/v9/channels/${channelId}/messages/`; // DMs
         }
         else {
-            API_SEARCH_URL = `https://discord.com/api/v6/guilds/${guildId}/messages/`; // Server
+            API_SEARCH_URL = `https://discord.com/api/v9/guilds/${guildId}/messages/`; // Server
         }
 
         const headers = {
@@ -166,7 +166,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 let resp;
                 try {
                     const s = Date.now();
-                    const API_DELETE_URL = `https://discord.com/api/v6/channels/${message.channel_id}/messages/${message.id}`;
+                    const API_DELETE_URL = `https://discord.com/api/v9/channels/${message.channel_id}/messages/${message.id}`;
                     resp = await fetch(API_DELETE_URL, {
                         headers,
                         method: 'DELETE'


### PR DESCRIPTION
v6 is deprecated for bot and client usage (though still functional), but it may not be maintained for much longer.

https://discord.com/developers/docs/reference