### PR TITLE
Fix bug where process is prematurely stopped due to receiving a full array of skippedMessages

### DIFF
--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -144,7 +144,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
         log.verb(`Estimated time remaining: ${etr}`)
 
 
-        if (messagesToDelete.length > 0) {
+        if (messagesToDelete.length > 0 || skippedMessages.length > 0) {
 
             if (++iterations < 1) {
                 log.verb(`Waiting for your confirmation...`);


### PR DESCRIPTION
Sometimes when deleting a large message set (in my specific case over 16k messages), you may populate up to the entire page size with messages that have to be skipped due to invalid type. The message "Ended because API returned an empty page." is displayed to the console, incorrectly informing the user of what actually happened.

If you stop and restart the process, the first page will be filled with messages that have to be skipped. This causes the script to prematurely fail instead of skipping to the next page.

This may possibly also resolve the following in a one line change:

- https://github.com/victornpb/deleteDiscordMessages/pull/218 
- https://github.com/victornpb/deleteDiscordMessages/discussions/290
- https://github.com/victornpb/deleteDiscordMessages/discussions/320
- https://github.com/victornpb/deleteDiscordMessages/discussions/298

**Console output before the fix:**
![image](https://user-images.githubusercontent.com/14187604/158092656-44da018f-5a4b-442d-8d73-c41abd4c6281.png)

**Console output after the fix:**
![image](https://user-images.githubusercontent.com/14187604/158092507-7c5974ba-2ed9-46cc-88fe-62c2ad71fc05.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/victornpb/deletediscordmessages/323)
<!-- Reviewable:end -->
