### PR TITLE
refactor: reduce number of @matchs

### DIFF
--- a/deleteDiscordMessages.user.js
+++ b/deleteDiscordMessages.user.js
@@ -3,15 +3,9 @@
 // @description   Extends the discord interface so you can mass delete messages from discord
 // @namespace     https://github.com/victornpb/deleteDiscordMessages
 // @version       4.2
-// @match         https://discord.com/app
-// @match         https://discord.com/channels/*
-// @match         https://discord.com/login
-// @match         https://ptb.discord.com/app
-// @match         https://ptb.discord.com/channels/*
-// @match         https://ptb.discord.com/login
-// @match         https://canary.discord.com/app
-// @match         https://canary.discord.com/channels/*
-// @match         https://canary.discord.com/login
+// @match         https://*.discord.com/app
+// @match         https://*.discord.com/channels/*
+// @match         https://*.discord.com/login
 // @downloadURL   https://raw.githubusercontent.com/victornpb/deleteDiscordMessages/master/deleteDiscordMessages.user.js
 // @homepageURL   https://github.com/victornpb/deleteDiscordMessages
 // @supportURL    https://github.com/victornpb/deleteDiscordMessages/issues


### PR DESCRIPTION
Looks like this should work. I tested the base discord.com domain as well and can confirm that was fine.

Didn't know about canary and ptb, but this should cover all of them in 3 lines instead of 9.

---

Sorry to mention you, Mr. Matchs. ^-^'
Didn't realize GitHub would convert the `@` in the commit to a mention.